### PR TITLE
Fix/escape single double quote

### DIFF
--- a/query/parse.js
+++ b/query/parse.js
@@ -35,7 +35,7 @@ define([ "./config" ], function (config) {
 										// Set / unset quote char
 					q = q === c
 						? UNDEFINED
-						: c;
+						: (q ? q : c);
 					break;
 
 				case OP_ID :

--- a/test/query/parse-test.js
+++ b/test/query/parse-test.js
@@ -190,6 +190,16 @@ define([ "../../query/parse" ], function (parse) {
 		        "raw": "test!\"123 321\""
 		    }]);
 		},
+		
+		"test!\"'123 321'\"": function () {
+		    var ast = parse("test!\"'123 321'\"");
+
+		    assert.equals(ast, [{
+		        "op": "!",
+		        "text": "test!\"'123 321'\"",
+		        "raw": "test!'123 321'"
+		    }]);
+		},
 
 		"test!'123 321'.p1,.'p2 asd'" : function () {
 			var ast = parse("test!'123 321'.p1,.'p2 asd'");

--- a/test/query/parse-test.js
+++ b/test/query/parse-test.js
@@ -181,23 +181,23 @@ define([ "../../query/parse" ], function (parse) {
 			}]);
 		},
 
-		"test!'\"123 321\"'": function () {
-		    var ast = parse("test!'\"123 321\"'");
-
+		/* respect the very first quote as escape character */
+		"test!'123\" 321\"'": function () {
+		    var ast = parse("test!'\"123\" 321'");
 		    assert.equals(ast, [{
 		        "op": "!",
-		        "text": "test!'\"123 321\"'",
-		        "raw": "test!\"123 321\""
+		        "text": "test!'\"123\" 321'",
+		        "raw": "test!\"123\" 321"
 		    }]);
 		},
-		
-		"test!\"'123 321'\"": function () {
-		    var ast = parse("test!\"'123 321'\"");
 
+		/* respect the very first quote as escape character */
+		"test!\"'123' 321\"": function () {
+		    var ast = parse("test!\"'123' 321\"");
 		    assert.equals(ast, [{
 		        "op": "!",
-		        "text": "test!\"'123 321'\"",
-		        "raw": "test!'123 321'"
+		        "text": "test!\"'123' 321\"",
+		        "raw": "test!'123' 321"
 		    }]);
 		},
 

--- a/test/query/parse-test.js
+++ b/test/query/parse-test.js
@@ -181,6 +181,16 @@ define([ "../../query/parse" ], function (parse) {
 			}]);
 		},
 
+		"test!'\"123 321\"'": function () {
+		    var ast = parse("test!'\"123 321\"'");
+
+		    assert.equals(ast, [{
+		        "op": "!",
+		        "text": "test!'\"123 321\"'",
+		        "raw": "test!\"123 321\""
+		    }]);
+		},
+
 		"test!'123 321'.p1,.'p2 asd'" : function () {
 			var ast = parse("test!'123 321'.p1,.'p2 asd'");
 


### PR DESCRIPTION
This reflects https://github.com/mu-lib/mu-data/pull/1
